### PR TITLE
Fix google-api-client version for compat with stackdriver

### DIFF
--- a/fluent-plugin-bigquery.gemspec
+++ b/fluent-plugin-bigquery.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency "test-unit-rr"
 
-  spec.add_runtime_dependency "google-api-client", ">= 0.11.0"
+  spec.add_runtime_dependency "google-api-client", "= 0.38.0"
   spec.add_runtime_dependency "googleauth", ">= 0.5.0"
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "fluentd", ">= 0.14.0", "< 2"

--- a/lib/fluent/plugin/bigquery/version.rb
+++ b/lib/fluent/plugin/bigquery/version.rb
@@ -1,5 +1,5 @@
 module Fluent
   module BigQueryPlugin
-    VERSION = "2.3.0".freeze
+    VERSION = "2.3.0-0misorobotics1".freeze
   end
 end


### PR DESCRIPTION
The previous minimum specification seems to cause an issue when trying
to install alongside fluent-plugin-google-cloud. Fixing it at 0.38.0
solves this issue.