### PR TITLE
Support Ruby >= 3.0

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -37,7 +37,7 @@ module Fluent
           definition.merge!(time_partitioning: time_partitioning) if time_partitioning
           definition.merge!(require_partition_filter: require_partition_filter) if require_partition_filter
           definition.merge!(clustering: clustering) if clustering
-          client.insert_table(project, dataset, definition, {})
+          client.insert_table(project, dataset, definition, **{})
           log.debug "create table", project_id: project, dataset: dataset, table: table_id
         rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError => e
           message = e.message
@@ -83,7 +83,7 @@ module Fluent
         if @options[:auto_create_table]
           res = insert_all_table_data_with_create_table(project, dataset, table_id, body, schema)
         else
-          res = client.insert_all_table_data(project, dataset, table_id, body, {})
+          res = client.insert_all_table_data(project, dataset, table_id, body, **{})
         end
         log.debug "insert rows", project_id: project, dataset: dataset, table: table_id, count: rows.size
 
@@ -343,7 +343,7 @@ module Fluent
 
       def insert_all_table_data_with_create_table(project, dataset, table_id, body, schema)
         try_count ||= 1
-        res = client.insert_all_table_data(project, dataset, table_id, body, {})
+        res = client.insert_all_table_data(project, dataset, table_id, body, **{})
       rescue Google::Apis::ClientError => e
         if e.status_code == 404 && /Not Found: Table/i =~ e.message
           if try_count == 1


### PR DESCRIPTION
This pull request fixes raising `ArgumentError` exception when run on Ruby >= 3.0 due to [incompatible changes of keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

I have confirmed that it works with the [td-agent package for Ubuntu 22.04](https://td-agent-package-browser.herokuapp.com/4/ubuntu/jammy/pool/contrib/t/td-agent), which [ships with ruby 3.1](https://github.com/fluent/fluent-package-builder/pull/381).

----

I am making this pull request for to draft because I need advice on modifying the test code.

I modified the test code in the same way:

```diff
--- a/test/plugin/test_out_bigquery_insert.rb
+++ b/test/plugin/test_out_bigquery_insert.rb
@@ -296,7 +296,7 @@ def test_write_with_row_based_table_id_formatting
           rows: [entry[0]],
           skip_invalid_rows: false,
           ignore_unknown_values: false
-        }, {}) { stub!.insert_errors { nil } }
+        }, **{}) { stub!.insert_errors { nil } }
     end

     driver.run do
```

I am getting the following error with ruby 2.7.

```
Failure: test_write_with_row_based_table_id_formatting(BigQueryInsertOutputTest):
  On subject #<Google::Apis::BigqueryV2::BigqueryService:0x000055f6fdcb8500>,
  unexpected method invocation:
    insert_all_table_data("yourproject_id", "yourdataset_id", "foo_2014_08_20", {:rows=>[{:json=>{:a=>"b", :created_at=>"2014_08_20"}}], :skip_invalid_rows=>false, :ignore_unknown_values=>false}, {})
  expected invocations:
  - insert_all_table_data("yourproject_id", "yourdataset_id", "foo_2014_08_20", {:rows=>[{:json=>{:a=>"b", :created_at=>"2014_08_20"}}], :skip_invalid_rows=>false, :ignore_unknown_values=>false})
```

However, if I use `{}` as it was before the modification, I am getting the following error with ruby 3.1.

```
Failure: test_write_with_row_based_table_id_formatting(BigQueryInsertOutputTest):
  On subject #<Google::Apis::BigqueryV2::BigqueryService:0x00007feebae30188>,
  unexpected method invocation:
    insert_all_table_data("yourproject_id", "yourdataset_id", "foo_2014_08_20", {:rows=>[{:json=>{:a=>"b", :created_at=>"2014_08_20"}}], :skip_invalid_rows=>false, :ignore_unknown_values=>false})
  expected invocations:
  - insert_all_table_data("yourproject_id", "yourdataset_id", "foo_2014_08_20", {:rows=>[{:json=>{:a=>"b", :created_at=>"2014_08_20"}}], :skip_invalid_rows=>false, :ignore_unknown_values=>false}, {})
```

I am not very familiar with ruby, so any advice on what modifications I should make would be appreciated.
