### PR TITLE
docs(readme): remove org old notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # fluent-plugin-bigquery
 
-## Notice
-
-We will transfer fluent-plugin-bigquery repository to [fluent-plugins-nursery](https://github.com/fluent-plugins-nursery) organization.
-It does not change maintenance plan.
-The main purpose is that it solves mismatch between maintainers and current organization. 
-
----
-
 [Fluentd](http://fluentd.org) output plugin to load/insert data into Google BigQuery.
 
 - **Plugin type**: Output


### PR DESCRIPTION
This PR removes the README organization's notice, given that the repo has already been transferred.