### PR TITLE
Fix keyword arguments handlings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.6
           - 2.7
           - 3.0
           - 3.1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
+        ruby:
+          - 2.7
+          - 3.0
+          - 3.1
         os:
           - windows-latest
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fluent-plugin-bigquery.gemspec
 gemspec
+
+gem "oj"
+gem "dummer"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ OAuth flow for installed applications.
 | v0.4.x         | 0.12.x          | 2.0 or later |
 | v1.x.x         | 0.14.x or later | 2.2 or later |
 | v2.x.x         | 0.14.x or later | 2.3 or later |
+| v3.x.x         | 1.x or later    | 2.7 or later |
 
 ## With docker image
 If you use official alpine based fluentd docker image (https://github.com/fluent/fluentd-docker-image),

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,14 @@
+# Requirements
+
+Set Environment Variable
+
+- GOOGLE_APPLICATION_CREDENTIALS (json key path)
+- PROJECT_NAME
+- DATASET_NAME
+- TABLE_NAME
+
+# How to use
+
+1. execute `create_table.sh`
+1. `bundle exec fluentd -c fluent.conf`
+1. `bundle exec dummer -c dummer_insert.rb` or `bundle exec dummer -c dummer_load.rb`

--- a/integration/create_table.sh
+++ b/integration/create_table.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -eux
+bq mk -t --project_id=${PROJECT_NAME} --schema=$(dirname $0)/schema.json ${DATASET_NAME}.${TABLE_NAME} 

--- a/integration/dummer_insert.rb
+++ b/integration/dummer_insert.rb
@@ -1,0 +1,12 @@
+require "time"
+
+configure "insert" do
+  host "localhost"
+  port 24224
+  rate 100
+  tag type: :string, any: %w(insert_data)
+  field :id, type: :integer, countup: true
+  field :string_field, type: :string, any: %w(str1 str2 str3 str4)
+  field :timestamp_field, type: :string, value: Time.now.iso8601
+  field :date, type: :string, value: Time.now.strftime("%Y-%m-%d")
+end

--- a/integration/dummer_load.rb
+++ b/integration/dummer_load.rb
@@ -1,0 +1,12 @@
+require "time"
+
+configure "load" do
+  host "localhost"
+  port 24224
+  rate 100
+  tag type: :string, any: %w(load_data)
+  field :id, type: :integer, countup: true
+  field :string_field, type: :string, any: %w(str1 str2 str3 str4)
+  field :timestamp_field, type: :string, value: Time.now.iso8601
+  field :date, type: :string, value: Time.now.strftime("%Y-%m-%d")
+end

--- a/integration/fluent.conf
+++ b/integration/fluent.conf
@@ -1,0 +1,88 @@
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+
+<match insert_data>
+  @id bigquery-insert-integration
+  @type bigquery_insert
+
+  allow_retry_insert_errors true
+
+  auth_method json_key
+  json_key "#{ENV["GOOGLE_APPLICATION_CREDENTIALS"]}"
+
+  <buffer>
+    @type file
+
+    chunk_limit_size 1m
+    chunk_limit_records 1500
+    total_limit_size 1g
+    path ./log/bigquery-insert-integration
+
+    flush_interval 30
+    flush_thread_count 4
+    flush_at_shutdown true
+
+    retry_max_times 14
+    retry_max_interval 30m
+  </buffer>
+
+  request_open_timeout_sec 2m
+
+  slow_flush_log_threshold 30.0
+
+  project "#{ENV["PROJECT_NAME"]}"
+  dataset "#{ENV["DATASET_NAME"]}"
+  table "#{ENV["TABLE_NAME"]}"
+  auto_create_table false
+  fetch_schema true
+  fetch_schema_table "#{ENV["TABLE_NAME"]}"
+
+  insert_id_field id
+
+  <secondary>
+    @type file
+    path ./log/bigquery-insert-integration.errors
+  </secondary>
+</match>
+
+<match load_data>
+  @id bigquery-load-integration
+  @type bigquery_load
+
+  auth_method json_key
+  json_key "#{ENV["GOOGLE_APPLICATION_CREDENTIALS"]}"
+
+  <buffer>
+    @type file
+
+    chunk_limit_size 1m
+    total_limit_size 1g
+    path ./log/bigquery-load-integration
+
+    flush_interval 120
+    flush_thread_count 4
+    flush_at_shutdown true
+
+    retry_max_times 14
+    retry_max_interval 30m
+  </buffer>
+
+  request_open_timeout_sec 2m
+
+  slow_flush_log_threshold 300.0
+
+  project "#{ENV["PROJECT_NAME"]}"
+  dataset "#{ENV["DATASET_NAME"]}"
+  table "#{ENV["TABLE_NAME"]}"
+  auto_create_table false
+  fetch_schema true
+  fetch_schema_table "#{ENV["TABLE_NAME"]}"
+
+  <secondary>
+    @type file
+    path ./log/bigquery-load-integration.errors
+  </secondary>
+</match>

--- a/integration/schema.json
+++ b/integration/schema.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "id",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "string_field",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "timestamp_field",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "date",
+    "type": "DATE",
+    "mode": "REQUIRED"
+  }
+]

--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -37,7 +37,7 @@ module Fluent
           definition.merge!(time_partitioning: time_partitioning) if time_partitioning
           definition.merge!(require_partition_filter: require_partition_filter) if require_partition_filter
           definition.merge!(clustering: clustering) if clustering
-          client.insert_table(project, dataset, definition, {})
+          client.insert_table(project, dataset, definition, **{})
           log.debug "create table", project_id: project, dataset: dataset, table: table_id
         rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError => e
           message = e.message
@@ -83,7 +83,7 @@ module Fluent
         if @options[:auto_create_table]
           res = insert_all_table_data_with_create_table(project, dataset, table_id, body, schema)
         else
-          res = client.insert_all_table_data(project, dataset, table_id, body, {})
+          res = client.insert_all_table_data(project, dataset, table_id, body, **{})
         end
         log.debug "insert rows", project_id: project, dataset: dataset, table: table_id, count: rows.size
 
@@ -343,7 +343,7 @@ module Fluent
 
       def insert_all_table_data_with_create_table(project, dataset, table_id, body, schema)
         try_count ||= 1
-        res = client.insert_all_table_data(project, dataset, table_id, body, {})
+        res = client.insert_all_table_data(project, dataset, table_id, body, **{})
       rescue Google::Apis::ClientError => e
         if e.status_code == 404 && /Not Found: Table/i =~ e.message
           if try_count == 1

--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -1,7 +1,7 @@
 module Fluent
   module BigQuery
     class Writer
-      def initialize(log, auth_method, options = {})
+      def initialize(log, auth_method, **options)
         @auth_method = auth_method
         @scope = "https://www.googleapis.com/auth/bigquery"
         @options = options
@@ -158,10 +158,8 @@ module Fluent
         res = client.insert_job(
           project,
           configuration,
-          {
-            upload_source: upload_source,
-            content_type: "application/octet-stream",
-          }
+          upload_source: upload_source,
+          content_type: "application/octet-stream",
         )
         JobReference.new(chunk_id, chunk_id_hex, project, dataset, table_id, res.job_reference.job_id)
       rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError => e

--- a/lib/fluent/plugin/out_bigquery_base.rb
+++ b/lib/fluent/plugin/out_bigquery_base.rb
@@ -131,7 +131,7 @@ module Fluent
       end
 
       def writer
-        @writer ||= Fluent::BigQuery::Writer.new(@log, @auth_method, {
+        @writer ||= Fluent::BigQuery::Writer.new(@log, @auth_method,
           private_key_path: @private_key_path, private_key_passphrase: @private_key_passphrase,
           email: @email,
           json_key: @json_key,
@@ -150,7 +150,7 @@ module Fluent
           clustering_fields: @clustering_fields,
           timeout_sec: @request_timeout_sec,
           open_timeout_sec: @request_open_timeout_sec,
-        })
+        )
       end
 
       def format(tag, time, record)

--- a/test/plugin/test_out_bigquery_insert.rb
+++ b/test/plugin/test_out_bigquery_insert.rb
@@ -5,6 +5,10 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
     Fluent::Test.setup
   end
 
+  def is_ruby2?
+    RUBY_VERSION.to_i < 3
+  end
+
   SCHEMA_PATH = File.join(File.dirname(__FILE__), "testdata", "apache.schema")
 
   CONFIG = %[
@@ -123,11 +127,15 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
     driver = create_driver
 
     stub_writer do |writer|
-      mock(writer.client).insert_all_table_data('yourproject_id', 'yourdataset_id', 'foo', {
+      args = ['yourproject_id', 'yourdataset_id', 'foo', {
         rows: [{json: hash_including(entry)}],
         skip_invalid_rows: false,
         ignore_unknown_values: false
-      }, {}) do
+      }]
+      if is_ruby2?
+        args << {}
+      end
+      mock(writer.client).insert_all_table_data(*args) do
         s = stub!
         s.insert_errors { nil }
         s
@@ -188,11 +196,15 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
 
       entry = {a: "b"}
       stub_writer do |writer|
-        mock(writer.client).insert_all_table_data('yourproject_id', 'yourdataset_id', 'foo', {
+        args = ['yourproject_id', 'yourdataset_id', 'foo', {
           rows: [{json: hash_including(entry)}],
           skip_invalid_rows: false,
           ignore_unknown_values: false
-        }, {}) do
+        }]
+        if is_ruby2?
+          args << {}
+        end
+        mock(writer.client).insert_all_table_data(*args) do
           ex = Google::Apis::ServerError.new("error", status_code: d["status_code"])
           raise ex
         end
@@ -247,11 +259,15 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
 
     entry = {a: "b"}
     stub_writer do |writer|
-      mock(writer.client).insert_all_table_data('yourproject_id', 'yourdataset_id', 'foo', {
+      args = ['yourproject_id', 'yourdataset_id', 'foo', {
         rows: [{json: hash_including(entry)}],
         skip_invalid_rows: false,
         ignore_unknown_values: false
-      }, {}) do
+      }]
+      if is_ruby2?
+        args << {}
+      end
+      mock(writer.client).insert_all_table_data(*args) do
         ex = Google::Apis::ServerError.new("error", status_code: 501)
         def ex.reason
           "invalid"
@@ -292,11 +308,15 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
     CONFIG
 
     stub_writer do |writer|
-      mock(writer.client).insert_all_table_data('yourproject_id', 'yourdataset_id', 'foo_2014_08_20', {
-          rows: [entry[0]],
-          skip_invalid_rows: false,
-          ignore_unknown_values: false
-        }, {}) { stub!.insert_errors { nil } }
+      args = ['yourproject_id', 'yourdataset_id', 'foo_2014_08_20', {
+        rows: [entry[0]],
+        skip_invalid_rows: false,
+        ignore_unknown_values: false
+      }]
+      if RUBY_VERSION.to_i < 3
+        args << {}
+      end
+      mock(writer.client).insert_all_table_data(*args) { stub!.insert_errors { nil } }
     end
 
     driver.run do
@@ -354,19 +374,27 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
         skip_invalid_rows: false,
         ignore_unknown_values: false,
       }
-      mock(writer.client).insert_all_table_data('yourproject_id', 'yourdataset_id', 'foo', body, {}) do
+      args = ['yourproject_id', 'yourdataset_id', 'foo', body]
+      if is_ruby2?
+        args << {}
+      end
+      mock(writer.client).insert_all_table_data(*args) do
         raise Google::Apis::ClientError.new("notFound: Not found: Table yourproject_id:yourdataset_id.foo", status_code: 404)
       end.at_least(1)
       mock(writer).sleep(instance_of(Numeric)) { nil }.at_least(1)
 
-      mock(writer.client).insert_table('yourproject_id', 'yourdataset_id', {
+      args = ['yourproject_id', 'yourdataset_id', {
         table_reference: {
           table_id: 'foo',
         },
         schema: {
           fields: schema_fields,
         },
-      }, {})
+      }]
+      if is_ruby2?
+        args << {}
+      end
+      mock(writer.client).insert_table(*args)
     end
 
     assert_raise(RuntimeError) do
@@ -432,12 +460,16 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
         skip_invalid_rows: false,
         ignore_unknown_values: false,
       }
-      mock(writer.client).insert_all_table_data('yourproject_id', 'yourdataset_id', 'foo', body, {}) do
+      args = ['yourproject_id', 'yourdataset_id', 'foo', body]
+      if is_ruby2?
+        args << {}
+      end
+      mock(writer.client).insert_all_table_data(*args) do
         raise Google::Apis::ClientError.new("notFound: Not found: Table yourproject_id:yourdataset_id.foo", status_code: 404)
       end.at_least(1)
       mock(writer).sleep(instance_of(Numeric)) { nil }.at_least(1)
 
-      mock(writer.client).insert_table('yourproject_id', 'yourdataset_id', {
+      args = ['yourproject_id', 'yourdataset_id', {
         table_reference: {
           table_id: 'foo',
         },
@@ -450,7 +482,11 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
           expiration_ms: 3600000,
         },
         require_partition_filter: true,
-      }, {})
+      }]
+      if is_ruby2?
+        args << {}
+      end
+      mock(writer.client).insert_table(*args)
     end
 
     assert_raise(RuntimeError) do
@@ -519,12 +555,16 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
         skip_invalid_rows: false,
         ignore_unknown_values: false,
       }
-      mock(writer.client).insert_all_table_data('yourproject_id', 'yourdataset_id', 'foo', body, {}) do
+      args = ['yourproject_id', 'yourdataset_id', 'foo', body]
+      if is_ruby2?
+        args << {}
+      end
+      mock(writer.client).insert_all_table_data(*args) do
         raise Google::Apis::ClientError.new("notFound: Not found: Table yourproject_id:yourdataset_id.foo", status_code: 404)
       end.at_least(1)
       mock(writer).sleep(instance_of(Numeric)) { nil }.at_least(1)
 
-      mock(writer.client).insert_table('yourproject_id', 'yourdataset_id', {
+      args = ['yourproject_id', 'yourdataset_id', {
         table_reference: {
           table_id: 'foo',
         },
@@ -542,7 +582,11 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
             'vhost',
           ],
         },
-      }, {})
+      }]
+      if is_ruby2?
+        args << {}
+      end
+      mock(writer.client).insert_table(*args)
     end
 
     assert_raise(RuntimeError) do

--- a/test/plugin/test_out_bigquery_insert.rb
+++ b/test/plugin/test_out_bigquery_insert.rb
@@ -9,6 +9,13 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
     RUBY_VERSION.to_i < 3
   end
 
+  def build_args(args)
+    if is_ruby2?
+      args << {}
+    end
+    args
+  end
+
   SCHEMA_PATH = File.join(File.dirname(__FILE__), "testdata", "apache.schema")
 
   CONFIG = %[
@@ -127,14 +134,11 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
     driver = create_driver
 
     stub_writer do |writer|
-      args = ['yourproject_id', 'yourdataset_id', 'foo', {
+      args = build_args(['yourproject_id', 'yourdataset_id', 'foo', {
         rows: [{json: hash_including(entry)}],
         skip_invalid_rows: false,
         ignore_unknown_values: false
-      }]
-      if is_ruby2?
-        args << {}
-      end
+      }])
       mock(writer.client).insert_all_table_data(*args) do
         s = stub!
         s.insert_errors { nil }
@@ -196,14 +200,11 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
 
       entry = {a: "b"}
       stub_writer do |writer|
-        args = ['yourproject_id', 'yourdataset_id', 'foo', {
+        args = build_args(['yourproject_id', 'yourdataset_id', 'foo', {
           rows: [{json: hash_including(entry)}],
           skip_invalid_rows: false,
           ignore_unknown_values: false
-        }]
-        if is_ruby2?
-          args << {}
-        end
+        }])
         mock(writer.client).insert_all_table_data(*args) do
           ex = Google::Apis::ServerError.new("error", status_code: d["status_code"])
           raise ex
@@ -259,14 +260,11 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
 
     entry = {a: "b"}
     stub_writer do |writer|
-      args = ['yourproject_id', 'yourdataset_id', 'foo', {
+      args = build_args(['yourproject_id', 'yourdataset_id', 'foo', {
         rows: [{json: hash_including(entry)}],
         skip_invalid_rows: false,
         ignore_unknown_values: false
-      }]
-      if is_ruby2?
-        args << {}
-      end
+      }])
       mock(writer.client).insert_all_table_data(*args) do
         ex = Google::Apis::ServerError.new("error", status_code: 501)
         def ex.reason
@@ -374,26 +372,20 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
         skip_invalid_rows: false,
         ignore_unknown_values: false,
       }
-      args = ['yourproject_id', 'yourdataset_id', 'foo', body]
-      if is_ruby2?
-        args << {}
-      end
+      args = build_args(['yourproject_id', 'yourdataset_id', 'foo', body])
       mock(writer.client).insert_all_table_data(*args) do
         raise Google::Apis::ClientError.new("notFound: Not found: Table yourproject_id:yourdataset_id.foo", status_code: 404)
       end.at_least(1)
       mock(writer).sleep(instance_of(Numeric)) { nil }.at_least(1)
 
-      args = ['yourproject_id', 'yourdataset_id', {
+      args = build_args(['yourproject_id', 'yourdataset_id', {
         table_reference: {
           table_id: 'foo',
         },
         schema: {
           fields: schema_fields,
         },
-      }]
-      if is_ruby2?
-        args << {}
-      end
+      }])
       mock(writer.client).insert_table(*args)
     end
 
@@ -460,16 +452,13 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
         skip_invalid_rows: false,
         ignore_unknown_values: false,
       }
-      args = ['yourproject_id', 'yourdataset_id', 'foo', body]
-      if is_ruby2?
-        args << {}
-      end
+      args = build_args(['yourproject_id', 'yourdataset_id', 'foo', body])
       mock(writer.client).insert_all_table_data(*args) do
         raise Google::Apis::ClientError.new("notFound: Not found: Table yourproject_id:yourdataset_id.foo", status_code: 404)
       end.at_least(1)
       mock(writer).sleep(instance_of(Numeric)) { nil }.at_least(1)
 
-      args = ['yourproject_id', 'yourdataset_id', {
+      args = build_args(['yourproject_id', 'yourdataset_id', {
         table_reference: {
           table_id: 'foo',
         },
@@ -482,10 +471,7 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
           expiration_ms: 3600000,
         },
         require_partition_filter: true,
-      }]
-      if is_ruby2?
-        args << {}
-      end
+      }])
       mock(writer.client).insert_table(*args)
     end
 
@@ -555,16 +541,13 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
         skip_invalid_rows: false,
         ignore_unknown_values: false,
       }
-      args = ['yourproject_id', 'yourdataset_id', 'foo', body]
-      if is_ruby2?
-        args << {}
-      end
+      args = build_args(['yourproject_id', 'yourdataset_id', 'foo', body])
       mock(writer.client).insert_all_table_data(*args) do
         raise Google::Apis::ClientError.new("notFound: Not found: Table yourproject_id:yourdataset_id.foo", status_code: 404)
       end.at_least(1)
       mock(writer).sleep(instance_of(Numeric)) { nil }.at_least(1)
 
-      args = ['yourproject_id', 'yourdataset_id', {
+      args = build_args(['yourproject_id', 'yourdataset_id', {
         table_reference: {
           table_id: 'foo',
         },
@@ -582,10 +565,7 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
             'vhost',
           ],
         },
-      }]
-      if is_ruby2?
-        args << {}
-      end
+      }])
       mock(writer.client).insert_table(*args)
     end
 

--- a/test/plugin/test_out_bigquery_insert.rb
+++ b/test/plugin/test_out_bigquery_insert.rb
@@ -283,7 +283,7 @@ class BigQueryInsertOutputTest < Test::Unit::TestCase
     assert_raise Fluent::BigQuery::UnRetryableError do
       driver.instance.write(chunk)
     end
-    assert_in_delta driver.instance.retry.secondary_transition_at , Time.now, 0.1
+    assert_in_delta driver.instance.retry.secondary_transition_at , Time.now, 0.2
     driver.instance_shutdown
   end
 

--- a/test/plugin/test_out_bigquery_load.rb
+++ b/test/plugin/test_out_bigquery_load.rb
@@ -64,7 +64,7 @@ class BigQueryLoadOutputTest < Test::Unit::TestCase
             max_bad_records: 0,
           }
         }
-      }, {upload_source: duck_type(:write, :sync, :rewind), content_type: "application/octet-stream"}) do
+      }, upload_source: duck_type(:write, :sync, :rewind), content_type: "application/octet-stream") do
         stub!.job_reference.stub!.job_id { "dummy_job_id" }
       end
     end
@@ -117,7 +117,7 @@ class BigQueryLoadOutputTest < Test::Unit::TestCase
           },
         },
         job_reference: {project_id: 'yourproject_id', job_id: satisfy { |x| x =~ /fluentd_job_.*/}} ,
-      }, {upload_source: duck_type(:write, :sync, :rewind), content_type: "application/octet-stream"}) do
+      }, upload_source: duck_type(:write, :sync, :rewind), content_type: "application/octet-stream") do
         stub!.job_reference.stub!.job_id { "dummy_job_id" }
       end
     end
@@ -154,7 +154,7 @@ class BigQueryLoadOutputTest < Test::Unit::TestCase
             max_bad_records: 0,
           }
         }
-      }, {upload_source: duck_type(:write, :sync, :rewind), content_type: "application/octet-stream"}) do
+      }, upload_source: duck_type(:write, :sync, :rewind), content_type: "application/octet-stream") do
         stub!.job_reference.stub!.job_id { "dummy_job_id" }
       end
 
@@ -237,7 +237,7 @@ class BigQueryLoadOutputTest < Test::Unit::TestCase
             max_bad_records: 0,
           }
         }
-      }, {upload_source: duck_type(:write, :sync, :rewind), content_type: "application/octet-stream"}) do
+      }, upload_source: duck_type(:write, :sync, :rewind), content_type: "application/octet-stream") do
         stub!.job_reference.stub!.job_id { "dummy_job_id" }
       end
 
@@ -317,7 +317,7 @@ class BigQueryLoadOutputTest < Test::Unit::TestCase
             },
           }
         }
-      }, {upload_source: duck_type(:write, :sync, :rewind), content_type: "application/octet-stream"}) do
+      }, upload_source: duck_type(:write, :sync, :rewind), content_type: "application/octet-stream") do
         stub!.job_reference.stub!.job_id { "dummy_job_id" }
       end
     end


### PR DESCRIPTION
I cherry-picked https://github.com/fluent-plugins-nursery/fluent-plugin-bigquery/pull/195 and add more fixes.

- Add double splat operator to empty hash for Ruby >= 3.0
- Fix keyword arguments handling to support ruby 3.0+
- Make Ruby-2.6 unsupported for the incompatibility of keyword arguments behavior.