### PR TITLE
Without execute `MultiJson.dump` when value is String type in format_one function

### DIFF
--- a/lib/fluent/plugin/bigquery/schema.rb
+++ b/lib/fluent/plugin/bigquery/schema.rb
@@ -72,7 +72,7 @@ module Fluent
       end
 
       def format_one(value, is_load: false)
-        if is_load
+        if is_load || value.is_a?(String)
           value
         else
           MultiJson.dump(value)


### PR DESCRIPTION
When a JSON type column receives a string, the value converted by the format_one function is successfully stored.
 However, in many cases, they are not in the expected form. 
Therefore, `MultiJson.dump(value)` is not executed.

