### PR TITLE
Fix testcase for new_column schema order

### DIFF
--- a/test/plugin/test_record_schema.rb
+++ b/test/plugin/test_record_schema.rb
@@ -74,14 +74,14 @@ class RecordSchemaTest < Test::Unit::TestCase
         "mode" => "NULLABLE"
       },
       {
-        "name" => "new_column",
-        "type" => "STRING",
-        "mode" => "REQUIRED"
-      },
-      {
         "name" => "bigutilisation",
         "type" => "BIGNUMERIC",
         "mode" => "NULLABLE"
+      },
+      {
+        "name" => "new_column",
+        "type" => "STRING",
+        "mode" => "REQUIRED"
       }
     ]
   end


### PR DESCRIPTION
The testcase schema definition in `test_load_schema_allow_overwrite_with_new_column` had the new column in the wrong position, which caused a failure.
This issue was introduced by changes from [PR #208](https://github.com/fluent-plugins-nursery/fluent-plugin-bigquery/pull/208).

The `new_column` in the schema was incorrectly defined before `bigutilisation`, but it should be placed after. ;I have corrected the order to ensure the test passes successfully.

