### PR TITLE
Install bundler and rake only once in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,6 +25,5 @@ jobs:
         CI: true
       run: |
         ruby -v
-        gem install bundler rake
         bundle install --jobs 4 --retry 3
         bundle exec rake test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,5 @@ jobs:
         CI: true
       run: |
         ruby -v
-        gem install bundler rake
         bundle install --jobs 4 --retry 3
         bundle exec rake test


### PR DESCRIPTION
This fixes the CI failure caused by an unsupported bundler version in Ruby 2.7. Since rspec is already listed in the Gemfile, this installation step was unnecessary.

The CI is still failing, but it will be resolved with the merge of #214.

