### PR TITLE
add missing location arguments for JobReference struct

### DIFF
--- a/lib/fluent/plugin/bigquery/writer.rb
+++ b/lib/fluent/plugin/bigquery/writer.rb
@@ -167,7 +167,7 @@ module Fluent
         log.error "job.load API", project_id: project, dataset: dataset, table: table_id, code: e.status_code, message: e.message
 
         if job_id && e.status_code == 409 && e.message =~ /Job/ # duplicate load job
-          return JobReference.new(chunk_id, chunk_id_hex, project, dataset, table_id, job_id)
+          return JobReference.new(chunk_id, chunk_id_hex, project, dataset, table_id, job_id, res.job_reference.location)
         end
 
         raise Fluent::BigQuery::Error.wrap(e)


### PR DESCRIPTION
This PR ensures that the missing `location` argument is properly passed to the JobReference in the error handler that runs when a duplicate job entry is inserted.

Please review the changes.